### PR TITLE
Add log level to cook

### DIFF
--- a/lib/spatula.rb
+++ b/lib/spatula.rb
@@ -22,7 +22,7 @@ module Spatula
     def install(name)
       file = JSON.parse(get_version_info(name))["file"]
       filename = File.basename(file)
-      # Use ENV['HOME'] as the base here 
+      # Use ENV['HOME'] as the base here
       tarball_dir = "#{ENV['HOME']}/.spatula/cookbook_tarballs"
       FileUtils.mkdir_p(tarball_dir)
       system "curl #{file} -o #{tarball_dir}/#{filename}"
@@ -36,11 +36,12 @@ module Spatula
     end
 
     desc "cook SERVER NODE", "Cook SERVER with the specification in config/NODE.js. Use local as the server to cook this box."
-    method_options :port => nil 
+    method_options :port => nil
     method_options :login    => nil
     method_options :identity => nil
+    method_options :log_level => nil
     def cook(server, node)
-      Cook.run(server, node, options[:port], options[:login], options[:identity])
+      Cook.run(server, node, options[:port], options[:login], options[:identity], options[:log_level])
     end
 
     desc "prepare SERVER", "Install software/libs required by chef on SERVER"

--- a/lib/spatula/cook.rb
+++ b/lib/spatula/cook.rb
@@ -3,9 +3,10 @@ module Spatula
   REMOTE_CHEF_PATH = "/tmp/chef-solo" # Where to find upstream cookbooks
 
   class Cook < SshCommand
-    def initialize(server, node, port=nil, login=nil, identity=nil)
+    def initialize(server, node, port=nil, login=nil, identity=nil, log_level=nil)
       super(server, port, login, identity)
       @node = node
+      @log_level = log_level
     end
 
     def run
@@ -34,7 +35,7 @@ module Spatula
 
     private
       def chef_cmd
-        "sudo chef-solo -c config/solo.rb -j config/#@node.json"
+        "sudo chef-solo -c config/solo.rb -j config/#@node.json -l #{ @log_level || 'info'}"
       end
   end
 end

--- a/lib/spatula/cook.rb
+++ b/lib/spatula/cook.rb
@@ -14,6 +14,16 @@ module Spatula
         raise "Syntax error in #{recipe}" if not ok
       end
 
+      Dir["**/*.json"].each do |json|
+        begin
+          require 'json'
+          # parse without instantiating Chef classes
+          JSON.parse File.read(json), :create_additions => false
+        rescue => error
+          raise "Syntax error in #{json}: #{error.message}"
+        end
+      end
+
       if @server =~ /^local$/i
         sh chef_cmd
       else


### PR DESCRIPTION
Hey trotter,

I added a json syntax check to to Cook#run. Also pass-thru --log-level to chef-solo command.

I've updated this in my rvm'ed gem; no problems using it yet.

-- Andrew
