### PR TITLE
Use build-essential instead of the compiler suite directly. Ubuntu 11 doe

### DIFF
--- a/lib/spatula/prepare.rb
+++ b/lib/spatula/prepare.rb
@@ -35,7 +35,7 @@ module Spatula
 
     def run_for_ubuntu
       ssh "#{sudo} apt-get update"
-      ssh "#{sudo} apt-get install -y ruby irb ri libopenssl-ruby1.8 libshadow-ruby1.8 ruby1.8-dev gcc g++ rsync curl"
+      ssh "#{sudo} apt-get install -y ruby irb ri libopenssl-ruby1.8 libshadow-ruby1.8 ruby1.8-dev build-essential rsync curl"
       install_rubygems
       install_chef
     end


### PR DESCRIPTION
Use build-essential instead of the compiler suite directly. Ubuntu 11 doesn't come with make by default.

Builds for ohai and pals fail because of this, so I thought I'd just send you a patch.

I have another patch idea, check your inbox!
