### PR TITLE
Removes "gems.opscode.com" from gem install sources

### DIFF
--- a/lib/spatula/prepare.rb
+++ b/lib/spatula/prepare.rb
@@ -79,7 +79,7 @@ module Spatula
     end
 
     def install_chef
-      ssh "#{sudo} gem install rdoc chef ohai --no-ri --no-rdoc --source http://gems.opscode.com --source http://gems.rubyforge.org"
+      ssh "#{sudo} gem install rdoc chef ohai --no-ri --no-rdoc --source http://gems.rubyforge.org"
     end
 
     def sudo


### PR DESCRIPTION
Been getting "bad response Not Found 404" from gems.opscode.com

"Request timeout" from ping.
